### PR TITLE
Update HandlerMappingImpl.java

### DIFF
--- a/src/de/willuhn/jameica/xmlrpc/server/HandlerMappingImpl.java
+++ b/src/de/willuhn/jameica/xmlrpc/server/HandlerMappingImpl.java
@@ -46,6 +46,9 @@ public class HandlerMappingImpl extends AbstractReflectiveHandlerMapping impleme
 
     try
     {
+      //Void Methoden sollen ebenfalls registriert werden
+      this.setVoidMethodEnabled(true)
+    
       // Wir registrieren unseren eigenen Request-Prozessor.
       // Andernfalls wuerde das Ding fuer jeden Request eine neue Instanz
       // des Services erzeugen. In unserer Impl halten wir die Instanzen

--- a/src/de/willuhn/jameica/xmlrpc/server/HandlerMappingImpl.java
+++ b/src/de/willuhn/jameica/xmlrpc/server/HandlerMappingImpl.java
@@ -47,7 +47,7 @@ public class HandlerMappingImpl extends AbstractReflectiveHandlerMapping impleme
     try
     {
       //Void Methoden sollen ebenfalls registriert werden
-      this.setVoidMethodEnabled(true)
+      this.setVoidMethodEnabled(true);
     
       // Wir registrieren unseren eigenen Request-Prozessor.
       // Andernfalls wuerde das Ding fuer jeden Request eine neue Instanz


### PR DESCRIPTION
Void Methoden können damit über xmlrpc aufgerufen werden. Bspw. der manuelle Start der Synchronisierung - hibiscus.server.execute.run